### PR TITLE
chore: simplify oauth redirect URI configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 OAUTH_HOST=https://oauth.example.com/
 OAUTH_CLIENT_ID=Abcde12346
 OAUTH_CLIENT_SECRET=C1entS3cr3t
-OAUTH_REDIRECT_URI=https://localhost:3000/auth/callback
+OAUTH_REDIRECT_URI=/auth/callback
 OAUTH_SCOPE=public read
 OAUTH_LOGOUT_URI=https://oauth.example.com/logout
 OAUTH_HOME=/dashboard

--- a/README.md
+++ b/README.md
@@ -65,17 +65,17 @@ if (isAlmostExpired(15)) {
 
 This module read enviroment variables directly.
 
-| Env Name                 | Default       | Description                                                                           |
-|--------------------------|---------------|---------------------------------------------------------------------------------------|
-| OAUTH_HOST               | -             | **(Required)** Oauth server's host                                                    |
-| OAUTH_CLIENT_ID          | -             | **(Required)** Oauth Client ID                                                        |
-| OAUTH_CLIENT_SECRET      | -             | **(Required)** Oauth Client Secret                                                    |
-| OAUTH_REDIRECT_URI       | -             | **(Required)** Oauth Callback URI                                                     |
-| OAUTH_SCOPE              | `public read` | Oauth scope                                                                           |
-| OAUTH_LOGOUT_URI         | -             | Oauth Logout URI                                                                      |
-| OAUTH_HOME               | `/`           | Redirect path after success login                                                     |
-| OAUTH_REGISTER           | `false`       | Add params register to Oauth Server                                                   |
-| OAUTH_REDIRECT_WHITELIST | -             | Redirect path after success login whitelist, for multiple value, use `;` as delimeter |
+| Env Name                 | Default          | Description                                                                           |
+|--------------------------|------------------|---------------------------------------------------------------------------------------|
+| OAUTH_HOST               | -                | **(Required)** Oauth server's host                                                    |
+| OAUTH_CLIENT_ID          | -                | **(Required)** Oauth Client ID                                                        |
+| OAUTH_CLIENT_SECRET      | -                | **(Required)** Oauth Client Secret                                                    |
+| OAUTH_REDIRECT_URI       | `/auth/callback` | Oauth Callback URI                                                     |
+| OAUTH_SCOPE              | `public read`    | Oauth scope                                                                           |
+| OAUTH_LOGOUT_URI         | -                | Oauth Logout URI                                                                      |
+| OAUTH_HOME               | `/`              | Redirect path after success login                                                     |
+| OAUTH_REGISTER           | `false`          | Add params register to Oauth Server                                                   |
+| OAUTH_REDIRECT_WHITELIST | -                | Redirect path after success login whitelist, for multiple value, use `;` as delimeter |
 
 👉 See [.env.example](/.env.example) for example
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -27,13 +27,13 @@ export function getEnv (profile: string, name: string): string {
 }
 
 export function getRedirectUri (event: H3Event, profile: string): string {
-  const redirectUrl = getEnv(profile, 'REDIRECT_URI')
+  const redirectUrl = getEnv(profile, 'REDIRECT_URI') || '/auth/callback'
   const url         = parseURL(redirectUrl)
   const requestUrl  = getRequestURL(event)
 
   const protocol = `${url.protocol ?? requestUrl.protocol}//`
   const host     = `${url.host ?? requestUrl.host}`
-  const path     = `${url.pathname ?? '/auth/callback'}`
+  const path     = `${url.pathname}`
 
   return `${protocol}${host}${path}`
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,3 +1,4 @@
+import { type H3Event, getRequestURL } from 'h3'
 import { decodePath, parseURL } from 'ufo'
 
 export function getHomeURL (profile: string, redirect?: string): string {
@@ -23,4 +24,16 @@ export function getHomeURL (profile: string, redirect?: string): string {
 
 export function getEnv (profile: string, name: string): string {
   return import.meta.env[`${profile.toUpperCase()}_${name.toUpperCase()}`]
+}
+
+export function getRedirectUri (event: H3Event, profile: string): string {
+  const redirectUrl = getEnv(profile, 'REDIRECT_URI')
+  const url         = parseURL(redirectUrl)
+  const requestUrl  = getRequestURL(event)
+
+  const protocol = `${url.protocol ?? requestUrl.protocol}//`
+  const host     = `${url.host ?? requestUrl.host}`
+  const path     = `${url.pathname ?? '/auth/callback'}`
+
+  return `${protocol}${host}${path}`
 }

--- a/src/runtime/callback.ts
+++ b/src/runtime/callback.ts
@@ -12,6 +12,7 @@ import type { CookieSerializeOptions } from 'cookie-es'
 import {
   getEnv,
   getHomeURL,
+  getRedirectUri,
 } from '../core/utils'
 import { getClient } from '../core/client'
 
@@ -29,7 +30,7 @@ export default defineEventHandler(async (event) => {
     const homeURL = getHomeURL(profile, state.redirect)
     const access  = await client.getToken({
       code        : query.code as string,
-      redirect_uri: getEnv(profile, 'REDIRECT_URI'),
+      redirect_uri: getRedirectUri(event, profile),
       scope       : getEnv(profile, 'SCOPE') || 'public read',
     })
 

--- a/src/runtime/login.ts
+++ b/src/runtime/login.ts
@@ -6,7 +6,7 @@ import {
 } from 'h3'
 import { withQuery } from 'ufo'
 import { useRuntimeConfig } from '#imports'
-import { getEnv } from '../core/utils'
+import { getEnv, getRedirectUri } from '../core/utils'
 import { getClient } from '../core/client'
 
 export default defineEventHandler(async (event) => {
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
 
     const client       = getClient(profile)
     const authorizeURL = client.authorizeURL({
-      redirect_uri: getEnv(profile, 'REDIRECT_URI'),
+      redirect_uri: getRedirectUri(event, profile),
       scope       : getEnv(profile, 'SCOPE') || 'public read',
       state       : query ? JSON.stringify(query) : '{}',
     })

--- a/src/runtime/logout.ts
+++ b/src/runtime/logout.ts
@@ -7,7 +7,7 @@ import {
 } from 'h3'
 import { withQuery } from 'ufo'
 import { useRuntimeConfig } from '#imports'
-import { getEnv } from '../core/utils'
+import { getRedirectUri, getEnv } from '../core/utils'
 
 export default defineEventHandler(async (event) => {
   const config  = useRuntimeConfig()
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
   const logoutUrl = withQuery(getEnv(profile, 'LOGOUT_URI'), {
     response_type: 'code',
     client_id    : getEnv(profile, 'CLIENT_ID'),
-    redirect_uri : getEnv(profile, 'REDIRECT_URI'),
+    redirect_uri : getRedirectUri(event, profile),
     scope        : getEnv(profile, 'SCOPE') || 'public read',
     state        : query ? JSON.stringify(query) : '{}',
   })


### PR DESCRIPTION
Set default OAuth redirect URI path

This PR introduces a change to simplify the configuration of the OAuth redirect URI. Previously, the full URI including protocol and host had to be specified. With this update, the `OAUTH_REDIRECT_URI` can be set without the need to include the protocol and host.

Changes:
- Added support for specifying the `OAUTH_REDIRECT_URI` path only
- Set the default path for the OAuth redirect URI to "/auth/callback"