### PR TITLE
[Feat] Skip redirection when samesite cookie is not strict and not inside iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ const {
 } = useNuAuth('github')
 ```
 
+## Disable redirection page
+
+To prevent displaying the redirection page, you can set the sameSite attribute of the cookie to `lax` or `none`. 
+
+```js
+export default defineNuxtConfig({
+  // ...
+  nuauth: {
+    // ...
+    cookie: {
+      sameSite: 'lax', // or 'none' for cross-origin cookies
+    }
+    // ...
+  }
+})
+
 ## Contribution
 
 - Clone this repository

--- a/src/runtime/callback.ts
+++ b/src/runtime/callback.ts
@@ -2,7 +2,6 @@ import {
   defineEventHandler,
   getQuery,
   setCookie,
-  send,
   setResponseStatus,
 } from 'h3'
 import { useRuntimeConfig } from '#imports'
@@ -47,9 +46,7 @@ export default defineEventHandler(async (event) => {
     if (state.enterprise)
       setCookie(event, `${profile}/enterprise-token`, state.enteprise)
 
-    // Use meta refresh as redirection to fix issue with cookies samesite=strict
-    // See: https://stackoverflow.com/questions/42216700/how-can-i-redirect-after-oauth2-with-samesite-strict-and-still-get-my-cookies
-    await send(event, getRedirectPage(homeURL), 'text/html')
+    await getRedirectPage(event, homeURL, cookieConfig)
   } catch (error) {
     setResponseStatus(event, 500)
 


### PR DESCRIPTION
This PR introduces an enhancement to directly redirect users to the callback destination without displaying the intermediate redirect page in scenarios where the sameSite cookie configuration is not set to `strict`and the application is not running inside an iframe.

Previously, the application would show an intermediate redirect page before reaching the callback. This behavior could lead to unnecessary user interactions and potentially affect user experience.

With this enhancement, we have modified the authentication process to skip the intermediate page and directly redirect users to the callback when the sameSite cookie is not set to `strict` and the application is not running inside an iframe. This ensures a seamless authentication flow and reduces user friction.